### PR TITLE
Update the README file, add solutions for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run -p 7000:7000 dbcccc/ttsfm:latest
 ```
 
 Note:
-For Apple macOS, if port 7000 is occupied by the Control Center, you can use an alternative local port like 5051:
+For Apple macOS, if port 7000 is occupied by the Control Center, you can use an alternative local port like 5051:  
 For Intel chips:
 ```bash
 docker pull dbcccc/ttsfm:latest

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ docker pull dbcccc/ttsfm:latest
 docker run -p 7000:7000 dbcccc/ttsfm:latest
 ```
 
+Note:
+For Apple macOS, if port 7000 is occupied by the Control Center, you can use an alternative local port like 5051:
+For Intel chips:
+```bash
+docker pull dbcccc/ttsfm:latest
+docker run -p 5051:7000 dbcccc/ttsfm:latest
+```
+For Apple Silicon (M-series) chips, in the repository's current directory:
+```bash
+docker build -t ttsfm .
+docker run -p 5051:7000 ttsfm
+```
+For Mac, access the web interface at `http://localhost:5051`.
+
 #### Option 2: Manual Installation
 1. Clone the repository:
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,13 +22,13 @@ docker pull dbcccc/ttsfm:latest
 docker run -p 7000:7000 dbcccc/ttsfm:latest
 ```
 注：
-如果是Apple Mac OS，7000端口若被中心控制器占用，可以换一个本地端口比如5051，可以使用以下命令：
+如果是Apple Mac OS，7000端口若被中心控制器占用，可以换一个本地端口比如5051，可以使用以下命令：  
 Intel 芯片可以直接使用
 ```bash
 docker pull dbcccc/ttsfm:latest
 docker run -p 5051:7000 dbcccc/ttsfm:latest
 ```
-M系列芯片可以在仓库当前目录使用：
+M系列芯片可以在仓库当前目录使用：  
 ```bash
 docker build -t ttsfm .
 docker run -p 5051:7000 ttsfm

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,6 +21,19 @@ TTSFM 是一个逆向工程的 API 服务器，镜像了 OpenAI 的 TTS 服务�
 docker pull dbcccc/ttsfm:latest
 docker run -p 7000:7000 dbcccc/ttsfm:latest
 ```
+注：
+如果是Apple Mac OS，7000端口若被中心控制器占用，可以换一个本地端口比如5051，可以使用以下命令：
+Intel 芯片可以直接使用
+```bash
+docker pull dbcccc/ttsfm:latest
+docker run -p 5051:7000 dbcccc/ttsfm:latest
+```
+M系列芯片可以在仓库当前目录使用：
+```bash
+docker build -t ttsfm .
+docker run -p 5051:7000 ttsfm
+```
+  Mac 网页地址使用 `http://localhost:5051`.
 
 #### 选项二：手动安装
 1. 克隆仓库：


### PR DESCRIPTION
Update the README file, add solutions for port occupation for macOS users and solutions for different chip architectures.

大佬，你的docker 镜像目前只有amd64的，没有arm64的，arm芯片的不支持，现在的mac 基本都是arm  芯片的。
<img width="698" alt="image" src="https://github.com/user-attachments/assets/03f70804-61ec-476a-9f14-16f47dc1db58" />

可以看看同时发布多架构的镜像，我写了一个文档：
https://catnip-doom-411.notion.site/Publishing-Multi-Architecture-Docker-Images-1bcfca8a060380b78176d5f568f526dc?pvs=4

Builds for both AMD64 (Intel/AMD) and ARM64 (Apple Silicon/ARM) architectures

这样pull images时会自动选择合适的架构到本机上。

<img width="597" alt="image" src="https://github.com/user-attachments/assets/5d314011-17e2-4cea-ab2d-748559603087" />

