### PR TITLE
Potential fix for code scanning alert no. 71: URL redirection from remote source

### DIFF
--- a/ttsfm-web/app.py
+++ b/ttsfm-web/app.py
@@ -254,18 +254,25 @@ def _is_safe_url(target: Optional[str]) -> bool:
 
     Allows only relative URLs or absolute URLs that match this server's host
     and http/https schemes. Prevents open redirects to external domains.
+    Handles backslashes and malformed URLs.
     """
     if not target:
         return False
 
-    # Build an absolute URL based on the current host, then compare
+    # Remove backslashes (browsers treat them as slashes)
+    target = target.replace('\\', '')
+
+    # Parse the target URL
     ref_url = urlparse(request.host_url)
     test_url = urlparse(urljoin(request.host_url, target))
+
+    # Only allow relative URLs (no scheme/netloc) or absolute URLs to this host
+    if not urlparse(target).netloc and not urlparse(target).scheme:
+        return True
     return (
         test_url.scheme in ("http", "https")
         and ref_url.netloc == test_url.netloc
     )
-
 @app.route('/set-language/<lang_code>')
 def set_language(lang_code):
     """Set the user's language preference."""


### PR DESCRIPTION
Potential fix for [https://github.com/dbccccccc/ttsfm/security/code-scanning/71](https://github.com/dbccccccc/ttsfm/security/code-scanning/71)

To fix the problem, we need to strengthen the `_is_safe_url` function to handle edge cases that `urlparse` and `urljoin` may miss. Specifically, we should remove backslashes from the target URL before parsing, and ensure that malformed URLs (such as those with a single slash after the scheme) are not considered safe. The function should only allow relative URLs or absolute URLs that match the current host and use http/https schemes. The fix should be applied in the `_is_safe_url` function in ttsfm-web/app.py, lines 252-268. No changes are needed elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
