### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dbccccccc/ttsfm&type=Date)](https://www.star-history.com/#dbccccccc/ttsfm&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dbccccccc/ttsfm&type=Date)](https://star-history.dera.page/#dbccccccc/ttsfm&Date)
 
 ## Overview
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dbccccccc/ttsfm&type=Date)](https://www.star-history.com/#dbccccccc/ttsfm&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dbccccccc/ttsfm&type=Date)](https://star-history.dera.page/#dbccccccc/ttsfm&Date)
 
 ## 概述
 


### PR DESCRIPTION
The star history chart on the README was broken and not loading for visitors. This change updates the chart link in both the English and Chinese README files so the chart displays correctly again.

This fix is necessary because the chart is one of the first things visitors see on the project page, and it was showing nothing at all.